### PR TITLE
Ignore rows with empty title

### DIFF
--- a/tv/tv.py
+++ b/tv/tv.py
@@ -3478,8 +3478,8 @@ def get_dialog_input_title(element):
         if element.text:
             result = element.text
         else:
-            checkbox_label = find_element(element, 'span[class^="label"] > span[class^="label"]')
-            result = checkbox_label.text
+            # Prevent that Kairos crashes when a title is empty. Simply ignore these elements and show a warning
+            log.warning('Element {} has no title. It will be ignored.'.format(element.id))
     except Exception as e:
         log.exception(e)
     return strip_to_ascii(result).strip('<>:; ').lower().replace(' ', '_')
@@ -3527,12 +3527,15 @@ def get_indicator_dialog_values(browser):
             class_name = row.get_attribute('class')
             if class_name.find('separator') >= 0:
                 continue
-            title = get_dialog_input_title(
-                find_element(row, 'div[class*="first"] > div, span[class^="label"] span[class^="label"], div[class^="label"] span[class^="label"]'))
-            value_cells = get_indicator_dialog_elements(browser, title)
-            value = get_dialog_input_value(value_cells)
-            if value is not None:
-                result[title] = value
+
+            # If title is empty, ignore this row
+            if title:
+                title = get_dialog_input_title(
+                    find_element(row, 'div[class*="first"] > div, span[class^="label"] span[class^="label"], div[class^="label"] span[class^="label"]'))
+                value_cells = get_indicator_dialog_elements(browser, title)
+                value = get_dialog_input_value(value_cells)
+                if value is not None:
+                    result[title] = value
 
         for title in result:
             if len(result[title]) == 1:


### PR DESCRIPTION
Kairos throws a fatal exception when encountering an element / row that has no title.

The reason for the crash is that the current code assumes that when there's no title the element must be a checkbox. That's not the case. It can also be just an element with no title.

In my testing reading the title of checkbox elements didn't require any special lookup. The `element.text` just works. That's why I've removed that code from the else statement and replaced it with a warning. Please check if this doesn't break anything.

The consequence of this change is that elements that have no title will not appear in default_inputs.

Example pine code to test reading of checkbox title using element.text
`checkbox = input.bool(true, title='my checkbox')`

Example pine code to test ignoring of rows with no title.
`input.color(title='', defval=color.new(#D1D4DC, 0), inline='FILL_COLORS_INLINE_1')`