### PR TITLE
Changed how permissions are set

### DIFF
--- a/kairos/tools.py
+++ b/kairos/tools.py
@@ -437,9 +437,7 @@ def set_permission(path):
         owner = stat.S_IRWXU
         group = stat.S_IRWXG
         other = stat.S_IRWXO
-        os.chmod(path, owner)
-        os.chmod(path, group)
-        os.chmod(path, other)
+        os.chmod(path, owner | group | other)
         return True
     except Exception as e:
         return e


### PR DESCRIPTION
In order to set 777 permission on an OSX system, the individual permissions need to be OR-ed. Not sure if this is the same on linux and windows.