### PR TITLE
Switch to new headless mode

### DIFF
--- a/tv/tv.py
+++ b/tv/tv.py
@@ -2999,7 +2999,9 @@ def create_browser(run_in_background, resolution='1920,1080', download_path=None
             options.add_argument("--disable-dev-shm-usage")
         # run chrome in the background
         if run_in_background:
-            options.add_argument('--headless')
+            # swiching to the new headless mode
+            # https://developer.chrome.com/articles/new-headless/
+            options.add_argument('--headless=new')
         # fix for https://stackoverflow.com/questions/40514022/chrome-webdriver-produces-timeout-in-selenium
         # options.add_argument("--dns-prefetch-disable")
 


### PR DESCRIPTION
I ran into a problem with Chrome driver version 110 where it would throw an `unable to discover open pages` error when using the shared folder setting on a headless machine. Switching to the new headless mode fixes the issue.  

This is a breaking change as it will require using a Chrome driver version 110+  so proceed with care.

More info on the new headless mode can be found here:
https://developer.chrome.com/articles/new-headless/